### PR TITLE
chore(ci): remove redundant build on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
- removing duplicate build trigger on push to main
- PRs already validate code before merge
- release.yml handles tag-triggered builds
- eliminates unnecessary 3-platform builds on every merge